### PR TITLE
Adding issues blocker support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <version.surefire>2.20.1</version.surefire>
 
     <!-- dependency versions -->
-    <version.commons-io>1.3.2</version.commons-io>
+    <version.commons-io>2.5</version.commons-io>
     <version.jackson>2.9.4</version.jackson>
     <version.logback>1.2.3</version.logback>
     <version.projectlombok>1.16.20</version.projectlombok>
@@ -39,7 +39,7 @@
 
     <!-- https://commons.apache.org -->
     <dependency>
-      <groupId>org.apache.commons</groupId>
+      <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>${version.commons-io}</version>
     </dependency>
@@ -91,6 +91,13 @@
       <artifactId>testng</artifactId>
       <version>${version.testng}</version>
       <scope>test</scope>
+    </dependency>
+
+    <!-- https://mvnrepository.com/artifact/org.yaml/snakeyaml -->
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.20</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/com/redhat/qe/kiali/ui/UIAbstract.java
+++ b/src/main/java/com/redhat/qe/kiali/ui/UIAbstract.java
@@ -31,7 +31,7 @@ public abstract class UIAbstract extends CommonUtils {
     }
 
     protected List<String> children(String parentIdentifier, String childIdentifier) {
-        _logger.debug("identifier[parent:{{}}, child:{{}}]", parentIdentifier, childIdentifier);
+        _logger.trace("identifier[parent:{{}}, child:{{}}]", parentIdentifier, childIdentifier);
         WebElement parent = element(parentIdentifier);
         ArrayList<String> items = new ArrayList<String>();
         for (WebElement el : parent.findElements(By.xpath(childIdentifier))) {
@@ -41,13 +41,13 @@ public abstract class UIAbstract extends CommonUtils {
     }
 
     protected WebElement element(String identifier) {
-        _logger.debug("identifier:{{}}", identifier);
+        _logger.trace("identifier:{{}}", identifier);
         return driver.findElement(By.xpath(identifier));
     }
 
     protected WebElement element(String parentIdentifier, String childIdentifier, Object... arguments) {
         childIdentifier = format(childIdentifier, arguments);
-        _logger.debug("identifier[parent:{{}}, child:{{}}]", parentIdentifier, childIdentifier);
+        _logger.trace("identifier[parent:{{}}, child:{{}}]", parentIdentifier, childIdentifier);
         if (parentIdentifier != null) {
             WebElement parent = element(parentIdentifier);
             return parent.findElement(By.xpath(childIdentifier));
@@ -59,25 +59,25 @@ public abstract class UIAbstract extends CommonUtils {
 
     protected WebElement element(WebElement parent, String childIdentifier, Object... arguments) {
         childIdentifier = format(childIdentifier, arguments);
-        _logger.debug("identifier[parent:{{}}, child:{{}}]", parent.toString(), childIdentifier);
+        _logger.trace("identifier[parent:{{}}, child:{{}}]", parent.toString(), childIdentifier);
         return parent.findElement(By.xpath(childIdentifier));
     }
 
     protected List<WebElement> elements(String identifier) {
-        _logger.debug("identifier:{{}}", identifier);
+        _logger.trace("identifier:{{}}", identifier);
         return driver.findElements(By.xpath(identifier));
     }
 
     protected List<WebElement> elements(String parentIdentifier, String childIdentifier, Object... arguments) {
         childIdentifier = format(childIdentifier, arguments);
-        _logger.debug("identifier[parent:{{}}, child:{{}}]", parentIdentifier, childIdentifier);
+        _logger.trace("identifier[parent:{{}}, child:{{}}]", parentIdentifier, childIdentifier);
         WebElement parent = element(parentIdentifier);
         return parent.findElements(By.xpath(childIdentifier));
     }
 
     protected List<WebElement> elements(WebElement parent, String childIdentifier, Object... arguments) {
         childIdentifier = format(childIdentifier, arguments);
-        _logger.debug("identifier[parent:{{}}, child:{{}}]", parent.toString(), childIdentifier);
+        _logger.trace("identifier[parent:{{}}, child:{{}}]", parent.toString(), childIdentifier);
         return parent.findElements(By.xpath(childIdentifier));
     }
 
@@ -124,7 +124,7 @@ public abstract class UIAbstract extends CommonUtils {
         if (arguments != null && childIdentifier.length() > 0) {
             childIdentifier = format(childIdentifier, arguments);
         }
-        _logger.debug("identifier[parent:{{}}, child:{{}}], waitTime:{}ms",
+        _logger.trace("identifier[parent:{{}}, child:{{}}], waitTime:{}ms",
                 parentIdentifier, childIdentifier, waitTime);
         WebElement parent = null;
         if (parentIdentifier != null) {

--- a/src/main/java/com/redhat/qe/rest/jira/JiraRestClient.java
+++ b/src/main/java/com/redhat/qe/rest/jira/JiraRestClient.java
@@ -1,0 +1,63 @@
+package com.redhat.qe.rest.jira;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Map;
+
+import com.redhat.qe.kiali.rest.core.KialiHeader;
+import com.redhat.qe.kiali.rest.core.KialiHttpClient;
+import com.redhat.qe.kiali.rest.core.KialiHttpResponse;
+
+/**
+ * @author Jeeva Kandasamy (jkandasa)
+ */
+
+public class JiraRestClient extends KialiHttpClient {
+
+    private String baseUrl;
+    private String username;
+    private String password;
+
+    private KialiHeader header;
+
+    public JiraRestClient(String baseUrl, String username, String password) {
+        this(baseUrl, username, password, TRUST_HOST_TYPE.DEFAULT);
+    }
+
+    public JiraRestClient(String baseUrl, String username, String password, TRUST_HOST_TYPE trustHostType) {
+        super(trustHostType == null ? TRUST_HOST_TYPE.DEFAULT : trustHostType);
+        if (baseUrl.endsWith("/")) {
+            this.baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        } else {
+            this.baseUrl = baseUrl;
+        }
+        this.username = username;
+        this.password = password;
+        initClient();
+    }
+
+    private void initClient() {
+        header = KialiHeader.getDefault();
+        header.addJsonContentType();
+        header.addAuthorization(username, password);
+    }
+
+    public static ArrayList<String> getList(String values) {
+        ArrayList<String> list = new ArrayList<>();
+        String[] _values = values.split(",");
+        for (String _value : _values) {
+            list.add(_value.trim());
+        }
+        return list;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> issue(String idOrName) {
+        KialiHttpResponse response = doGet(
+                baseUrl + MessageFormat.format("/rest/api/latest/issue/{0}", idOrName),
+                header, STATUS_CODE.OK.getCode());
+        return (Map<String, Object>) readValue(response.getEntity(),
+                mapResolver().get(Map.class, String.class, Object.class));
+    }
+
+}

--- a/src/test/java/com/redhat/qe/kiali/ui/Driver.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/Driver.java
@@ -1,7 +1,6 @@
-package com.redhat.qe.kiali.ui.tests;
+package com.redhat.qe.kiali.ui;
 
 import com.redhat.qe.kiali.rest.KialiRestClient;
-import com.redhat.qe.kiali.ui.KialiWebDriver;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/test/java/com/redhat/qe/kiali/ui/DriverFactory.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/DriverFactory.java
@@ -1,4 +1,4 @@
-package com.redhat.qe.kiali.ui.tests;
+package com.redhat.qe.kiali.ui;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -14,7 +14,6 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import org.testng.ITestContext;
 
 import com.redhat.qe.kiali.rest.KialiRestClient;
-import com.redhat.qe.kiali.ui.KialiWebDriver;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/test/java/com/redhat/qe/kiali/ui/TestAbstract.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/TestAbstract.java
@@ -1,4 +1,4 @@
-package com.redhat.qe.kiali.ui.tests;
+package com.redhat.qe.kiali.ui;
 
 import java.net.MalformedURLException;
 import java.util.List;
@@ -12,13 +12,11 @@ import org.testng.annotations.BeforeTest;
 
 import com.redhat.qe.kiali.model.KeyValue;
 import com.redhat.qe.kiali.rest.KialiRestClient;
-import com.redhat.qe.kiali.ui.KialiWebDriver;
 import com.redhat.qe.kiali.ui.pages.RootPage;
 
 /**
  * @author Jeeva Kandasamy (jkandasa)
  */
-
 public abstract class TestAbstract {
     protected RootPage rootPage;
     protected boolean reloadPageBeforeMethod = true;

--- a/src/test/java/com/redhat/qe/kiali/ui/TestCount.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/TestCount.java
@@ -1,4 +1,4 @@
-package com.redhat.qe.kiali.ui.tests;
+package com.redhat.qe.kiali.ui;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/test/java/com/redhat/qe/kiali/ui/TestUtils.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/TestUtils.java
@@ -1,0 +1,66 @@
+package com.redhat.qe.kiali.ui;
+
+import java.io.File;
+import java.util.Map;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Jeeva Kandasamy (jkandasa)
+ */
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TestUtils {
+
+    @SuppressWarnings("unchecked")
+    public static Object getValue(Map<String, Object> source, String keyString, Object defaultValue) {
+        String[] keys = keyString.split("\\.");
+        Object value = null;
+        Map<String, Object> _source = source;
+        int keysSize = keys.length;
+        while (keysSize > 0) {
+            if (keysSize == 1) {
+                value = _source.get(keys[keys.length - keysSize]);
+                break;
+            } else {
+                _source = (Map<String, Object>) _source.get(keys[keys.length - keysSize]);
+                keysSize--;
+            }
+            if (_source == null) {
+                break;
+            }
+        }
+        if (value != null) {
+            return value;
+        }
+        return defaultValue;
+    }
+
+    public static File getFileFromResource(String filename) {
+        try {
+            //Get file from resources folder
+            ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+            return new File(classLoader.getResource(filename).getFile());
+        } catch (Exception ex) {
+            _logger.error("Exception on file[{}] query from resource ", filename, ex);
+            return null;
+        }
+    }
+
+    public static String getProperty(String key) {
+        return getProperty(key, null);
+    }
+
+    public static String getProperty(String key, String defaultValue) {
+        // check it on properties
+        String value = System.getProperty(key);
+        // check it on env variable
+        if (value == null) {
+            value = System.getenv(key);
+        }
+        return value != null ? value : defaultValue;
+    }
+}

--- a/src/test/java/com/redhat/qe/kiali/ui/YamlFactory.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/YamlFactory.java
@@ -1,0 +1,30 @@
+package com.redhat.qe.kiali.ui;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.apache.commons.io.FileUtils;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * @author Jeeva Kandasamy (jkandasa)
+ */
+
+public class YamlFactory {
+
+    public static HashMap<String, Object> getMap(String fileName) throws IOException {
+        return getMap(FileUtils.getFile(fileName));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static HashMap<String, Object> getMap(File file) throws IOException {
+        String yamlFile = getFileAsString(file);
+        final Yaml yaml = new Yaml();
+        return (HashMap<String, Object>) yaml.load(yamlFile);
+    }
+
+    private static String getFileAsString(File file) throws IOException {
+        return FileUtils.readFileToString(file, "UTF-8");
+    }
+}

--- a/src/test/java/com/redhat/qe/kiali/ui/bugtracker/Blocker.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/bugtracker/Blocker.java
@@ -1,0 +1,28 @@
+package com.redhat.qe.kiali.ui.bugtracker;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+
+/**
+ * @author Jeeva Kandasamy (jkandasa)
+ */
+
+@Data
+@Builder
+@ToString
+public class Blocker {
+    private String name;
+    private Map<String, String> list;
+    private boolean blocked;
+
+    public Map<String, String> getList() {
+        if (list == null) {
+            list = new HashMap<String, String>();
+        }
+        return list;
+    }
+}

--- a/src/test/java/com/redhat/qe/kiali/ui/bugtracker/BugTracker.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/bugtracker/BugTracker.java
@@ -59,7 +59,7 @@ public class BugTracker {
                 loadClients();
                 // load non-block list
                 List<String> jiraNonBlockList = (List<String>) TestUtils.getValue(
-                        yamlData, "bug-trackers.jira.non-block-list", new ArrayList<String>());
+                        yamlData, "bug-trackers.jira.non-blocking-list", new ArrayList<String>());
                 // load tests
                 HashMap<String, Object> tests = (HashMap<String, Object>) TestUtils.getValue(
                         yamlData, "blockers", new HashMap<String, Object>());

--- a/src/test/java/com/redhat/qe/kiali/ui/bugtracker/BugTracker.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/bugtracker/BugTracker.java
@@ -1,0 +1,108 @@
+package com.redhat.qe.kiali.ui.bugtracker;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.redhat.qe.kiali.ui.TestUtils;
+import com.redhat.qe.kiali.ui.YamlFactory;
+import com.redhat.qe.rest.jira.JiraRestClient;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Jeeva Kandasamy (jkandasa)
+ */
+
+@Slf4j
+public class BugTracker {
+    private static String yamlFile = null;
+    private static Map<String, Object> yamlData = null;
+    private static Map<String, Blocker> BLOCKERS = null;
+    private static JiraRestClient jiraCliet = null;
+
+    private static final String IDENTIFIER_JIRIA = "JR:";
+    private static final String KEY_BLOCKERS = "blockers";
+
+    public static Map<String, Blocker> getBlockers() {
+        if (BLOCKERS == null) {
+            BLOCKERS = new HashMap<String, Blocker>();
+            initialize();
+        }
+        return BLOCKERS;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static void initialize() {
+        if (yamlData == null) {
+            try {
+                // update yaml file
+                yamlFile = TestUtils.getProperty(KEY_BLOCKERS);
+                if (yamlFile == null) { // check it on source
+                    //Get file from resources folder
+                    File file = TestUtils.getFileFromResource("blockers.yaml");
+                    if (file != null) {
+                        yamlData = YamlFactory.getMap(file);
+                    }
+                } else {
+                    yamlData = YamlFactory.getMap(yamlFile);
+                }
+
+                if (yamlData == null) {
+                    _logger.warn("blockers yaml file not found! skipping bug status verification");
+                    return;
+                }
+
+                loadClients();
+                // load non-block list
+                List<String> jiraNonBlockList = (List<String>) TestUtils.getValue(
+                        yamlData, "bug-trackers.jira.non-block-list", new ArrayList<String>());
+                // load tests
+                HashMap<String, Object> tests = (HashMap<String, Object>) TestUtils.getValue(
+                        yamlData, "blockers", new HashMap<String, Object>());
+                _logger.debug("Tests:{}", tests);
+                for (String test : tests.keySet()) {
+                    _logger.debug("Test:{}", test);
+                    Map<String, String> bugList = new HashMap<String, String>();
+                    for (String bugId : (List<String>) tests.get(test)) {
+                        // Jira issue
+                        if (bugId.startsWith(IDENTIFIER_JIRIA)) {
+                            String currentState = (String) TestUtils.getValue(
+                                    jiraCliet.issue(bugId.replaceFirst(IDENTIFIER_JIRIA, "").trim()),
+                                    "fields.status.name", null);
+                            bugList.put(bugId, currentState.trim().toLowerCase());
+                        }
+                    }
+                    boolean isBlocked = false;
+                    for (String bugId : bugList.keySet()) {
+                        if (!jiraNonBlockList.contains(bugList.get(bugId))) {
+                            isBlocked = true;
+                        }
+                    }
+                    Blocker blocker = Blocker.builder()
+                            .name(test)
+                            .blocked(isBlocked)
+                            .list(bugList)
+                            .build();
+                    BLOCKERS.put(test, blocker);
+                }
+                _logger.debug("Blockers:{}", BLOCKERS);
+            } catch (IOException ex) {
+                _logger.error("Exception, ", ex);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void loadClients() {
+        // load Jira rest client
+        Map<String, Object> jiraConfig = (Map<String, Object>) TestUtils.getValue(
+                yamlData, "bug-trackers.jira", new HashMap<String, Object>());
+        _logger.debug("JiraConfig:{}", jiraConfig);
+        jiraCliet = new JiraRestClient((String) jiraConfig.get("url"), null, null);
+    }
+
+}

--- a/src/test/java/com/redhat/qe/kiali/ui/listeners/BlockersUpdateListener.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/listeners/BlockersUpdateListener.java
@@ -1,0 +1,47 @@
+package com.redhat.qe.kiali.ui.listeners;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.testng.IAnnotationTransformer;
+import org.testng.annotations.ITestAnnotation;
+
+import com.redhat.qe.kiali.ui.bugtracker.Blocker;
+import com.redhat.qe.kiali.ui.bugtracker.BugTracker;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Jeeva Kandasamy (jkandasa)
+ */
+
+@Slf4j
+public class BlockersUpdateListener implements IAnnotationTransformer {
+    @SuppressWarnings("rawtypes")
+    @Override
+    public void transform(ITestAnnotation annotation, Class clazz, Constructor constructor, Method testMethod) {
+        // if there is no blockers on list. skip below steps
+        if (BugTracker.getBlockers().isEmpty()) {
+            return;
+        }
+        String className = testMethod.getDeclaringClass().getCanonicalName();
+        String methodName = testMethod.getName();
+        _logger.debug("Checking blocker status for [Class:{}, Method:{}]", className, methodName);
+        if (BugTracker.getBlockers().get(className) != null) {
+            updateEnabled(annotation, BugTracker.getBlockers().get(className));
+        }
+        if (BugTracker.getBlockers().get(className + "." + methodName) != null) {
+            updateEnabled(annotation, BugTracker.getBlockers().get(className + "." + methodName));
+        }
+        if (!annotation.getEnabled()) {
+            _logger.info("Disabled this test:[class{}, method:{}]", className, methodName);
+        }
+    }
+
+    private void updateEnabled(ITestAnnotation annotation, Blocker blocker) {
+        _logger.debug("Checking this {}", blocker);
+        if (blocker.isBlocked()) {
+            annotation.setEnabled(false);
+        }
+    }
+}

--- a/src/test/java/com/redhat/qe/kiali/ui/listeners/KialiTestListener.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/listeners/KialiTestListener.java
@@ -1,4 +1,4 @@
-package com.redhat.qe.kiali.ui.tests;
+package com.redhat.qe.kiali.ui.listeners;
 
 import java.io.File;
 import java.util.concurrent.ConcurrentHashMap;
@@ -11,6 +11,12 @@ import org.testng.ISuiteListener;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
+
+import com.redhat.qe.kiali.ui.Driver;
+import com.redhat.qe.kiali.ui.DriverFactory;
+import com.redhat.qe.kiali.ui.TestCount;
+import com.redhat.qe.kiali.ui.bugtracker.Blocker;
+import com.redhat.qe.kiali.ui.bugtracker.BugTracker;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -118,6 +124,25 @@ public class KialiTestListener extends TestListenerAdapter implements ISuiteList
         }
         // call tearDown tasks
         DriverFactory.tearDownAll();
+
+        // known issues and current status
+        StringBuilder knownIssues = new StringBuilder();
+        for (String key : BugTracker.getBlockers().keySet()) {
+            Blocker blocker = BugTracker.getBlockers().get(key);
+            if (blocker.isBlocked()) {
+                knownIssues.append("\n\nName: ").append(blocker.getName());
+                knownIssues.append("\n--------------------------------------------------------------");
+                for (String issueId : blocker.getList().keySet()) {
+                    knownIssues.append("\n").append(issueId).append(": ").append(blocker.getList().get(issueId));
+                }
+            }
+        }
+        if (knownIssues.length() > 0) {
+            _logger.info("\n\n************* BLOCKING ISSUES STATUS *************************"
+                    + "{}"
+                    + "\n**************************************************************\n",
+                    knownIssues.toString());
+        }
     }
 
     // test listeners

--- a/src/test/java/com/redhat/qe/kiali/ui/tests/istiomixerrules/TestIstioMixerRulesPage.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/tests/istiomixerrules/TestIstioMixerRulesPage.java
@@ -10,6 +10,7 @@ import com.redhat.qe.kiali.model.KeyValue;
 import com.redhat.qe.kiali.model.Namespace;
 import com.redhat.qe.kiali.model.SortOption;
 import com.redhat.qe.kiali.model.rules.Rule;
+import com.redhat.qe.kiali.ui.TestAbstract;
 import com.redhat.qe.kiali.ui.components.Filter;
 import com.redhat.qe.kiali.ui.components.Pagination;
 import com.redhat.qe.kiali.ui.components.SortDropdown;
@@ -17,7 +18,6 @@ import com.redhat.qe.kiali.ui.enums.IstioMixerPageEnum.FILTER;
 import com.redhat.qe.kiali.ui.enums.IstioMixerPageEnum.SORT;
 import com.redhat.qe.kiali.ui.enums.PaginationEnum.PERPAGE;
 import com.redhat.qe.kiali.ui.pages.IstioMixerRulesPage;
-import com.redhat.qe.kiali.ui.tests.TestAbstract;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/test/java/com/redhat/qe/kiali/ui/tests/menu/TestMenu.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/tests/menu/TestMenu.java
@@ -6,9 +6,9 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.redhat.qe.kiali.ui.TestAbstract;
 import com.redhat.qe.kiali.ui.enums.RootPageEnum.MAIN_MENU;
 import com.redhat.qe.kiali.ui.pages.RootPage;
-import com.redhat.qe.kiali.ui.tests.TestAbstract;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/test/java/com/redhat/qe/kiali/ui/tests/menu/TestNavbar.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/tests/menu/TestNavbar.java
@@ -7,11 +7,11 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.redhat.qe.kiali.model.Version;
+import com.redhat.qe.kiali.ui.TestAbstract;
 import com.redhat.qe.kiali.ui.components.About;
 import com.redhat.qe.kiali.ui.enums.RootPageEnum.TOP_RIGHT_MENU;
 import com.redhat.qe.kiali.ui.enums.RootPageEnum.VERSION;
 import com.redhat.qe.kiali.ui.pages.RootPage;
-import com.redhat.qe.kiali.ui.tests.TestAbstract;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/test/java/com/redhat/qe/kiali/ui/tests/services/TestServicesPage.java
+++ b/src/test/java/com/redhat/qe/kiali/ui/tests/services/TestServicesPage.java
@@ -10,6 +10,7 @@ import com.redhat.qe.kiali.model.KeyValue;
 import com.redhat.qe.kiali.model.Namespace;
 import com.redhat.qe.kiali.model.SortOption;
 import com.redhat.qe.kiali.model.services.Service;
+import com.redhat.qe.kiali.ui.TestAbstract;
 import com.redhat.qe.kiali.ui.components.Filter;
 import com.redhat.qe.kiali.ui.components.Pagination;
 import com.redhat.qe.kiali.ui.components.SortDropdown;
@@ -17,7 +18,6 @@ import com.redhat.qe.kiali.ui.enums.PaginationEnum.PERPAGE;
 import com.redhat.qe.kiali.ui.enums.ServicesPageEnum.FILTER;
 import com.redhat.qe.kiali.ui.enums.ServicesPageEnum.SORT;
 import com.redhat.qe.kiali.ui.pages.ServicesPage;
-import com.redhat.qe.kiali.ui.tests.TestAbstract;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/test/resources/blockers.yaml
+++ b/src/test/resources/blockers.yaml
@@ -3,7 +3,7 @@
 bug-trackers:
   jira:
     url: https://issues.jboss.org
-    non-block-list:
+    non-blocking-list:
       - ready
 
 # blockers

--- a/src/test/resources/blockers.yaml
+++ b/src/test/resources/blockers.yaml
@@ -1,0 +1,14 @@
+--- # blockers list
+# bug tracker tools details
+bug-trackers:
+  jira:
+    url: https://issues.jboss.org
+    non-block-list:
+      - ready
+
+# blockers
+blockers:
+  com.redhat.qe.kiali.ui.tests.menu.TestMenu.testToggle:
+    - JR:KIALI-429
+  com.redhat.qe.kiali.ui.tests.menu.TestNavbar.testAbout:
+    - JR:KIALI-430

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="Kiali UI automtion[Java]">
   <listeners>
-    <listener class-name="com.redhat.qe.kiali.ui.tests.KialiTestListener"></listener>
+    <listener class-name="com.redhat.qe.kiali.ui.listeners.KialiTestListener"></listener>
+    <listener class-name="com.redhat.qe.kiali.ui.listeners.BlockersUpdateListener"></listener>
   </listeners>
 
 


### PR DESCRIPTION
now we can disable a `TestMethod` or a `TestCalss` by defining issues on `blockers.yaml` file as follows,

* update Jira tracking tool URL
* `non-blocking-list` - list of status string, says this issues fixed
* under `blockers`, add `testClass` name or `testMentod`(fully qualified name) with a list of blocking issues. If any one issue is on blocking state this test will be disabled.

```yaml
--- # blockers list
# bug tracker tools details
bug-trackers:
  jira:
    url: https://issues.jboss.org
    non-blocking-list:
      - ready

# blockers
blockers:
  com.redhat.qe.kiali.ui.tests.menu.TestMenu.testToggle:
    - JR:KIALI-429
  com.redhat.qe.kiali.ui.tests.menu.TestNavbar.testAbout:
    - JR:KIALI-430
```